### PR TITLE
Skip notify when blank message

### DIFF
--- a/capistrano-chatwork.gemspec
+++ b/capistrano-chatwork.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'capistrano'
   spec.add_runtime_dependency 'cha', '~> 1.1.0'
+  spec.add_runtime_dependency 'activesupport'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake'

--- a/lib/capistrano-chatwork/utility.rb
+++ b/lib/capistrano-chatwork/utility.rb
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 require 'cha'
+require 'active_support/core_ext'
 
 module CapistranoChatWork
   module Utility
@@ -15,6 +16,7 @@ module CapistranoChatWork
     end
 
     def notify(message)
+      return if message.blank?
       client = Cha::Client.new(api_token: fetch(:chatwork_api_token))
       client.create_room_message(fetch(:chatwork_room_id), message)
     end


### PR DESCRIPTION
# Why?

I want to notify only deploy success or failed
# Usage

When only explicitly set `nil`, `false` or blank string, skip notify
# Example

``` ruby
# skip deploy start notification
set :chatwork_deploy_started_message, false

# skip deploy finished notification
set :chatwork_deploy_finished_message, nil

# skip deploy failed notification
set :chatwork_deploy_failed_message, ""
```
