### PR TITLE
Please require 'active_support' 

### DIFF
--- a/lib/capistrano-chatwork/utility.rb
+++ b/lib/capistrano-chatwork/utility.rb
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 require 'cha'
+require 'active_support'
 require 'active_support/core_ext'
 
 module CapistranoChatWork


### PR DESCRIPTION
I have `NameError: uninitialized constant ActiveSupport::Deprecation`

```rb
[feature/deploy]~/projects/: cap production chatwork:notify_deploy_started --trace
** Invoke production (first_time)
** Execute production
** Invoke load:defaults (first_time)
** Execute load:defaults
cap aborted!
NameError: uninitialized constant ActiveSupport::Deprecation
/Users/osada/projects/vendor/bundle/gems/activesupport-4.2.0/lib/active_support/core_ext/module/deprecation.rb:21:in `deprecate'
```

It's a same problem.

[uninitialized constant ActiveSupport::Autoload (NameError), sometimes, at ramdom · Issue #14664 · rails/rails](https://github.com/rails/rails/issues/14664#issuecomment-40191673)

Please use `active_support`.