### PR TITLE
Relax cha dependency for ChatWork API v2

### DIFF
--- a/capistrano-chatwork.gemspec
+++ b/capistrano-chatwork.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'capistrano'
-  spec.add_runtime_dependency 'cha', '~> 1.1.0'
+  spec.add_runtime_dependency 'cha', '~> 1.1'
   spec.add_runtime_dependency 'activesupport'
 
   spec.add_development_dependency 'bundler', '~> 1.6'


### PR DESCRIPTION
I want to use [cha](https://github.com/mitukiii/cha) v1.2.0. but dependency is conflict :cry:

Gemfile 

```ruby
group :development do
  gem "cha", ">= 1.2.0", require: false
  gem "capistrano-chatwork", require: false
end
```

```sh
$ bundle update cha

Bundler could not find compatible versions for gem "cha":
  In Gemfile:
    cha (>= 1.2.0)

    capistrano-chatwork was resolved to 1.3.0, which depends on
      cha (~> 1.1.0)
```

So I relaxed dependency